### PR TITLE
Improve layout spacing and consistency in Provides component

### DIFF
--- a/src/components/Provides/Provides.tsx
+++ b/src/components/Provides/Provides.tsx
@@ -26,7 +26,7 @@ export default function Provides() {
             <ul className="flex flex-wrap text-boulder-dust text-[20px]/[22px] gap-y-[42px] gap-x-2 mb-[42px] max-[991px]:flex-col max-[991px]:items-stretch 1xl:flex-row">
               <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Флоромат (квіткомат) - обладнання для продажу авторських
-                квіткових компози��ій та сувенірів.
+                квіткових композицій та сувенірів.
               </li>
               <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Таке обладнання забезпечує автономну реалізацію квітів без

--- a/src/components/Provides/Provides.tsx
+++ b/src/components/Provides/Provides.tsx
@@ -10,9 +10,9 @@ export default function Provides() {
             Як це працює?
           </h2>
         </div>
-        <div className="flex flex-col lg:flex-row lg:flex-wrap">
+        <div className="flex flex-col lg:flex-row lg:flex-wrap gap-6">
           {/* Left column: image only */}
-          <div className="flex flex-col lg:w-[48%] 1xl:w-[32%] mr-auto mb-5 max-[991px]:mt-auto max-[991px]:mb-6 mb-0 mr-0 ml-0 max-[991px]:items-center max-[991px]:justify-center">
+          <div className="flex flex-col lg:w-[48%] 1xl:w-[32%] max-[1023px]:items-center max-[1023px]:justify-center">
             <img
               loading="lazy"
               src="https://cdn.builder.io/api/v1/image/assets%2F72ae2a4d99034a3aa7809f652e4e761b%2F2eed2cabd7bb4c308d76431764a8bf3a"
@@ -24,22 +24,22 @@ export default function Provides() {
           {/* Right column: content lists */}
           <div className="flex flex-col 1xl:flex-row 1xl:flex-wrap mr-auto lg:w-[48%] 1xl:w-[65%]">
             <ul className="flex flex-wrap text-boulder-dust text-[20px]/[22px] gap-y-[42px] gap-x-1.5 mb-[42px] max-[991px]:flex-col max-[991px]:items-stretch 1xl:flex-row">
-              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:max-w-[49%] 3xl:max-w-[49%] 4xl:max-w-[49%]">
+              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Флоромат (квіткомат) - обладнання для продажу авторських
                 квіткових композицій та сувенірів.
               </li>
-              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:max-w-[49%] 3xl:max-w-[49%] 4xl:max-w-[49%]">
+              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Таке обладнання забезпечує автономну реалізацію квітів без
                 участі продавців.
               </li>
-              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:max-w-[49%] 3xl:max-w-[49%] 4xl:max-w-[49%]">
+              <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Ми надаємо місце та обладнання. Ви контролюєте реалізацію та
                 прибуток.
               </li>
             </ul>
 
             <ul className="flex flex-wrap text-[18px]/[28px] font-semibold gap-y-[42px] gap-x-1.5 1xl:flex-row">
-              <li className="flex gap-6 h-16 items-center max-w-[456px] w-full 1xl:max-w-[49%] 1xl:w-auto">
+              <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img
                     src="/images/icons-png/cleaning.png"
@@ -51,7 +51,7 @@ export default function Provides() {
                   Цілодобові продажі 24 години на добу, 7 днів на тиждень
                 </div>
               </li>
-              <li className="flex gap-6 h-16 items-center max-w-[456px] w-full 1xl:max-w-[49%] 1xl:w-auto">
+              <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img
                     src="/images/icons-png/health.png"
@@ -63,7 +63,7 @@ export default function Provides() {
                   Швидка окупність інвестицій до двох років
                 </div>
               </li>
-              <li className="flex gap-6 h-16 items-center max-w-[456px] w-full 1xl:max-w-[49%] 1xl:w-auto">
+              <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img
                     src="/images/icons-png/flowers.png"
@@ -78,7 +78,7 @@ export default function Provides() {
                   </div>
                 </div>
               </li>
-              <li className="flex gap-6 h-16 items-center max-w-[456px] w-full 1xl:max-w-[49%] 1xl:w-auto">
+              <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img
                     src="/images/icons-png/cargo.png"
@@ -90,7 +90,7 @@ export default function Provides() {
                   Найкраща локація з найбільшим пішим трафіком
                 </div>
               </li>
-              <li className="flex gap-6 h-16 items-center max-w-[456px] w-full 1xl:max-w-[49%] 1xl:w-auto">
+              <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img
                     src="/images/icons-png/secure.png"

--- a/src/components/Provides/Provides.tsx
+++ b/src/components/Provides/Provides.tsx
@@ -23,10 +23,10 @@ export default function Provides() {
 
           {/* Right column: content lists */}
           <div className="flex flex-col 1xl:flex-row 1xl:flex-wrap mr-auto lg:w-[48%] 1xl:w-[65%]">
-            <ul className="flex flex-wrap text-boulder-dust text-[20px]/[22px] gap-y-[42px] gap-x-1.5 mb-[42px] max-[991px]:flex-col max-[991px]:items-stretch 1xl:flex-row">
+            <ul className="flex flex-wrap text-boulder-dust text-[20px]/[22px] gap-y-[42px] gap-x-2 mb-[42px] max-[991px]:flex-col max-[991px]:items-stretch 1xl:flex-row">
               <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Флоромат (квіткомат) - обладнання для продажу авторських
-                квіткових композицій та сувенірів.
+                квіткових компози��ій та сувенірів.
               </li>
               <li className="tracking-[0.02em] 3xl:tracking-[0.07em] 1xl:tracking-normal lg:max-w-114 1xl:w-[49%]">
                 Таке обладнання забезпечує автономну реалізацію квітів без
@@ -38,7 +38,7 @@ export default function Provides() {
               </li>
             </ul>
 
-            <ul className="flex flex-wrap text-[18px]/[28px] font-semibold gap-y-[42px] gap-x-1.5 1xl:flex-row">
+            <ul className="flex flex-wrap text-[18px]/[28px] font-semibold gap-y-[42px] gap-x-2 1xl:flex-row">
               <li className="flex gap-6 items-center max-w-[456px] w-full 1xl:w-[49%]">
                 <span className="flex justify-start lg:justify-center items-center w-16 h-16 rounded-full bg-woodsmoke-dark shrink-0">
                   <img


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user was working on visual changes to improve the layout and spacing of the Provides component, specifically focusing on the element at line 77:29 in the component file.

## Code changes
- **Added gap spacing**: Added `gap-6` class to the main flex container for consistent spacing between elements
- **Simplified responsive classes**: Removed complex margin/padding combinations (`mr-auto mb-5`, `mb-0 mr-0 ml-0`) and replaced with cleaner responsive utilities
- **Improved breakpoint consistency**: Updated responsive classes to use `max-[1023px]` instead of `max-[991px]` for better alignment
- **Standardized width classes**: Replaced `max-w-[49%]` with `w-[49%]` for more consistent sizing across list items
- **Enhanced gap spacing**: Increased horizontal gap from `gap-x-1.5` to `gap-x-2` for better visual separation
- **Removed fixed height constraints**: Removed `h-16` from list items while keeping it on icon containers for better flexibility
- **Cleaned up width utilities**: Removed redundant `1xl:w-auto` classes in favor of consistent `1xl:w-[49%]`

These changes improve the overall visual consistency and responsive behavior of the component layout.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7dd4ab0b020240d4892775eeccdad6ca/quantum-field)

👀 [Preview Link](https://7dd4ab0b020240d4892775eeccdad6ca-quantum-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7dd4ab0b020240d4892775eeccdad6ca</projectId>-->
<!--<branchName>quantum-field</branchName>-->